### PR TITLE
Advertise participant on multicast, SequenceNumberSet fixes/tests, simplify GAP sending, logging cleanup

### DIFF
--- a/src/ParticipantView.ts
+++ b/src/ParticipantView.ts
@@ -30,7 +30,6 @@ export class ParticipantView {
 
   readonly localReaderIdToRemoteWriterId = new Map<EntityId, EntityId>();
   readonly localWriterIdToRemoteReaderIds = new Map<EntityId, EntityId[]>();
-  readonly remoteReaderIdToLocalWriterId = new Map<EntityId, EntityId>();
   readonly remoteWriterIdToLocalReaderIds = new Map<EntityId, EntityId[]>();
 
   constructor(local: Participant, remote: ParticipantAttributes) {
@@ -137,7 +136,6 @@ export class ParticipantView {
 
       // Is there a local writer that matches this remote reader?
       if (hasBuiltinEndpoint(local.attributes.availableBuiltinEndpoints, writerFlag)) {
-        this.remoteReaderIdToLocalWriterId.set(readerEntityId, writerEntityId);
         addToMultiMap(writerEntityId, readerEntityId, this.localWriterIdToRemoteReaderIds);
       }
     }

--- a/src/common/SequenceNumberSet.test.ts
+++ b/src/common/SequenceNumberSet.test.ts
@@ -1,0 +1,73 @@
+import { SequenceNumberSet } from "./SequenceNumberSet";
+
+describe("SequenceNumberSet", () => {
+  it("constructs empty", () => {
+    const set = new SequenceNumberSet(1n, 0);
+    expect(set.base).toEqual(1n);
+    expect(set.numBits).toEqual(0);
+    expect(set.size).toEqual(12);
+    expect(set.empty()).toEqual(true);
+    expect(set.maxSequenceNumber()).toEqual(1n);
+    expect(Array.from(set.sequenceNumbers())).toEqual([]);
+    expect(set.bitmap).toEqual(new Uint32Array([0, 0, 0, 0, 0, 0, 0, 0]));
+  });
+
+  it("constructs with numBits", () => {
+    const set = new SequenceNumberSet(2n, 1);
+    expect(set.base).toEqual(2n);
+    expect(set.numBits).toEqual(1);
+    expect(set.size).toEqual(16);
+    expect(set.empty()).toEqual(false);
+    expect(set.maxSequenceNumber()).toEqual(2n);
+    expect(Array.from(set.sequenceNumbers())).toEqual([]);
+    expect(set.bitmap).toEqual(new Uint32Array([0, 0, 0, 0, 0, 0, 0, 0]));
+  });
+
+  it("constructs with numBits and bitmap", () => {
+    const set = new SequenceNumberSet(3n, 42, new Uint32Array([1, 2, 3, 4, 5, 6, 7, 8]));
+    expect(set.base).toEqual(3n);
+    expect(set.numBits).toEqual(42);
+    expect(set.size).toEqual(20);
+    expect(set.empty()).toEqual(false);
+    expect(set.maxSequenceNumber()).toEqual(44n);
+    expect(Array.from(set.sequenceNumbers())).toEqual([34n]); // base 3 + 31st bit set
+    expect(set.bitmap).toEqual(new Uint32Array([1, 2, 3, 4, 5, 6, 7, 8]));
+  });
+
+  it("adds", () => {
+    const set = new SequenceNumberSet(2n, 3);
+    expect(set.maxSequenceNumber()).toEqual(4n);
+    expect(Array.from(set.sequenceNumbers())).toEqual([]);
+    expect(set.add(1n)).toEqual(false);
+    expect(set.add(4n)).toEqual(true);
+    expect(set.add(5n)).toEqual(false);
+    expect(set.add(6n)).toEqual(false);
+    expect(set.add(2n)).toEqual(true);
+    expect(set.maxSequenceNumber()).toEqual(4n);
+    expect(Array.from(set.sequenceNumbers())).toEqual([2n, 4n]);
+    expect(set.bitmap).toEqual(new Uint32Array([2684354560, 0, 0, 0, 0, 0, 0, 0]));
+  });
+
+  it("write / fromData", () => {
+    const set = new SequenceNumberSet(2n, 3);
+    expect(set.add(4n)).toEqual(true);
+    expect(set.add(2n)).toEqual(true);
+
+    const buffer = new ArrayBuffer(set.size);
+    const data = new Uint8Array(buffer);
+    const view = new DataView(buffer);
+    set.write(view, 0, true);
+    expect(data).toEqual(new Uint8Array([
+      0, 0, 0, 0,
+      2, 0, 0, 0,
+      3, 0, 0, 0,
+      0, 0, 0, 160,
+    ])); // prettier-ignore
+
+    const set2 = SequenceNumberSet.fromData(view, 0, true);
+    expect(set.base).toEqual(set2.base);
+    expect(set.numBits).toEqual(set2.numBits);
+    expect(set.bitmap).toEqual(set2.bitmap);
+    expect(Array.from(set2.sequenceNumbers())).toEqual([2n, 4n]);
+  });
+});

--- a/src/common/SequenceNumberSet.ts
+++ b/src/common/SequenceNumberSet.ts
@@ -4,76 +4,63 @@ const MAX_BITS = 256;
 const MAX_ITEMS = 8;
 
 export class SequenceNumberSet {
-  private base_: SequenceNumber;
-  private numBits_: number;
-  private bitmap_: Uint32Array;
-
-  get base(): SequenceNumber {
-    return this.base_;
-  }
-
-  get numBits(): number {
-    return this.numBits_;
-  }
-
-  get bitmap(): Readonly<Uint32Array> {
-    return this.bitmap_;
-  }
+  readonly base: SequenceNumber;
+  readonly numBits: number;
+  readonly bitmap: Uint32Array;
 
   get size(): number {
-    const numLongs = Math.floor((this.numBits_ + 31) / 32);
+    const numLongs = Math.floor((this.numBits + 31) / 32);
     return 8 + 4 + numLongs * 4;
   }
 
   constructor(base: SequenceNumber, numBits: number, bitmap?: Uint32Array) {
-    this.base_ = base;
-    this.numBits_ = Math.min(numBits, MAX_BITS);
-    this.bitmap_ = new Uint32Array(MAX_ITEMS);
+    this.base = base;
+    this.numBits = Math.min(numBits, MAX_BITS);
+    this.bitmap = new Uint32Array(MAX_ITEMS);
     if (bitmap != undefined) {
-      this.bitmap_.set(bitmap.length > MAX_ITEMS ? bitmap.slice(0, MAX_ITEMS) : bitmap);
+      this.bitmap.set(bitmap.length > MAX_ITEMS ? bitmap.slice(0, MAX_ITEMS) : bitmap);
     }
   }
 
   empty(): boolean {
-    return this.numBits_ === 0;
+    return this.numBits === 0;
   }
 
   add(sequenceNum: SequenceNumber): boolean {
-    const idx = Number(sequenceNum - this.base_);
-    if (idx < 0 || idx >= MAX_BITS) {
+    const idx = Number(sequenceNum - this.base);
+    if (idx < 0 || idx >= this.numBits) {
       return false;
     }
-    this.numBits_ = Math.max(idx + 1, this.numBits_);
     const offset = idx >> 5;
-    this.bitmap_[offset] |= 1 << (31 - (idx & 31));
+    this.bitmap[offset] |= 1 << (31 - (idx & 31));
     return true;
   }
 
   write(output: DataView, offset: number, littleEndian: boolean): void {
-    sequenceNumberToData(this.base_, output, offset, littleEndian);
-    output.setUint32(offset + 8, this.numBits_, littleEndian);
-    const numLongs = this.size;
+    sequenceNumberToData(this.base, output, offset, littleEndian);
+    output.setUint32(offset + 8, this.numBits, littleEndian);
+    const numLongs = Math.floor((this.numBits + 31) / 32);
     for (let i = 0; i < numLongs; i++) {
-      output.setUint32(offset + 12 + i * 4, this.bitmap_[i]!, littleEndian);
+      output.setUint32(offset + 12 + i * 4, this.bitmap[i]!, littleEndian);
     }
   }
 
   maxSequenceNumber(): SequenceNumber {
-    return this.base_ + BigInt(this.numBits_);
+    return this.base + BigInt(Math.max(0, this.numBits - 1));
   }
 
   *sequenceNumbers(): Generator<SequenceNumber> {
     let offset = 0;
     let idx = 0;
-    for (let i = 0; i < this.numBits_; i += 32) {
-      const data = this.bitmap_[offset++] ?? 0;
+    for (let i = 0; i < this.numBits; i += 32) {
+      const data = this.bitmap[offset++] ?? 0;
       for (let j = 0; j < 32; j++) {
         const datamask = 1 << (31 - j);
         if ((data & datamask) === datamask) {
-          yield this.base_ + BigInt(idx);
+          yield this.base + BigInt(idx);
         }
         ++idx;
-        if (idx >= this.numBits_) {
+        if (idx >= this.numBits) {
           break;
         }
       }


### PR DESCRIPTION
With this PR we immediately establish a connection to peers without waiting (up to eight seconds) to passively receive a participant broadcast. GAP sending code has been simplified, at the risk of sending more data but it was arguably a premature optimization until this code is hardened. `SequenceNumberSet` bugs have been fixed and tests added.