### PR TITLE
Bump @foxglove/cdr to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@foxglove/cdr": "^1.1.1",
+    "@foxglove/cdr": "^2.0.0",
     "@foxglove/rostime": "^1.1.0",
     "avl": "^1.5.2",
     "eventemitter3": "^4.0.7"

--- a/src/Participant.ts
+++ b/src/Participant.ts
@@ -966,15 +966,13 @@ export class Participant extends EventEmitter<ParticipantEvents> {
     serializedData: Uint8Array,
   ): void => {
     const writerGuid = makeGuid(guidPrefix, writerEntityId);
-    const sequenceNumber = writerSeqNumber;
-    const data = serializedData;
 
     // Get all of our readers for this writer
     const readers = this.getReaders(readerEntityId, writerGuid);
     this._log?.debug?.(
       `  [SUBMSG] DATA reader=${this.readerName(readerEntityId)} writer=${this.writerName(
         writerEntityId,
-      )} ${data.length} bytes (seq ${sequenceNumber}) from ${writerGuid}, ${
+      )} ${serializedData.length} bytes (seq ${writerSeqNumber}) from ${writerGuid}, ${
         readers.length
       } reader(s)`,
     );
@@ -1022,8 +1020,8 @@ export class Participant extends EventEmitter<ParticipantEvents> {
         timestamp,
         kind: ChangeKind.Alive,
         writerGuid,
-        sequenceNumber,
-        data,
+        sequenceNumber: writerSeqNumber,
+        data: serializedData,
         instanceHandle,
       });
     }

--- a/src/messaging/ParametersView.ts
+++ b/src/messaging/ParametersView.ts
@@ -25,15 +25,16 @@ export class ParametersView {
   constructor(reader: CdrReader) {
     this.map = new Map<ParameterId, unknown>();
 
+    const byteLength = reader.byteLength;
     let nextOffset = reader.decodedBytes;
-    while (nextOffset < reader.data.byteLength) {
+    while (nextOffset < byteLength) {
       reader.seekTo(nextOffset);
       const parameterId = reader.uint16();
       const parameterLength = reader.uint16();
       nextOffset = reader.decodedBytes + parameterLength;
       const value = getParameterValue(parameterId, parameterLength, reader);
       if (isMultiParameter(parameterId)) {
-        let array = this.map.get(parameterId) as unknown[];
+        let array = this.map.get(parameterId) as unknown[] | undefined;
         if (array == undefined) {
           array = [];
           this.map.set(parameterId, array);
@@ -134,7 +135,7 @@ export class ParametersView {
   }
 
   expectsInlineQoS(): boolean {
-    return (this.map.get(ParameterId.PID_EXPECTS_INLINE_QOS) as boolean) ?? false;
+    return (this.map.get(ParameterId.PID_EXPECTS_INLINE_QOS) as boolean | undefined) ?? false;
   }
 
   static FromCdr(serializedData: Uint8Array): ParametersView | undefined {

--- a/yarn.lock
+++ b/yarn.lock
@@ -324,10 +324,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@foxglove/cdr@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@foxglove/cdr/-/cdr-1.1.1.tgz#c0a77713ba67b2ed6feaf5f64fa8c50fe713534d"
-  integrity sha512-Bv5bjHCh4K3x8OdBvt/0W+EEUIrDlM7+rLj2/LpguUXET51EsBVACCzYRvvZtQdAkJUZxVhuRnI3e8+rISWNcg==
+"@foxglove/cdr@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@foxglove/cdr/-/cdr-2.0.0.tgz#12bade26e1525e522fc9f0366830e65e5cb52e27"
+  integrity sha512-Zu00eJyO05bX9js7/E2QfQNjG8p7jNhE/vUuTF2lO+MS89/kLDb/b6fle8krLy7Bnd7ClKv6G4JAmiqy6wKwEA==
 
 "@foxglove/eslint-plugin@0.14.0":
   version "0.14.0"


### PR DESCRIPTION
This ensures the CdrReader#byteLength getter is accessible for decoding parameters, fixing a crash when this library was used with @foxglove/cdr v1.2.x
