### PR TITLE
Don't truncate last four bytes of DATA payloads

### DIFF
--- a/src/Participant.ts
+++ b/src/Participant.ts
@@ -1182,7 +1182,7 @@ export class Participant extends EventEmitter<ParticipantEvents> {
       // Send preemptive heartbeats for participant readers
       void this.sendInitialHeartbeats(participant);
     } else {
-      this._log?.info?.(`updating participant ${guidPrefix}`);
+      this._log?.debug?.(`updating participant ${guidPrefix}`);
       participant.update(participantData);
     }
 

--- a/src/messaging/MessageView.test.ts
+++ b/src/messaging/MessageView.test.ts
@@ -72,15 +72,15 @@ describe("MessageView", () => {
     expect(dataMsg.serializedData[1]).toEqual(3);
     expect(dataMsg.serializedData[2]).toEqual(0);
     expect(dataMsg.serializedData[3]).toEqual(0);
-    expect(dataMsg.serializedData).toHaveLength(224);
-    expect(dataMsg.serializedData).toEqual(data.slice(56, 56 + 224));
+    expect(dataMsg.serializedData).toHaveLength(228);
+    expect(dataMsg.serializedData).toEqual(data.slice(56, 56 + 228));
     expect(dataMsg.effectiveTimestamp).toEqual({ sec: 1625943731, nsec: 1222751420 });
 
     let params = ParametersView.FromCdr(dataMsg.serializedData)!;
     expect(params).toBeDefined();
-    expect(params.allParameters().size).toEqual(11);
+    expect(params.allParameters().size).toEqual(12);
     params = ParametersView.FromCdr(dataMsg.serializedData)!;
-    expect(params.allParameters().size).toEqual(11);
+    expect(params.allParameters().size).toEqual(12);
 
     const allParams = params.allParameters();
     const userData = allParams.get(ParameterId.PID_USER_DATA) as Uint8Array;

--- a/src/messaging/submessages/Data.ts
+++ b/src/messaging/submessages/Data.ts
@@ -83,7 +83,7 @@ export class DataMsgView extends SubMessageView {
   }
 
   get serializedData(): Uint8Array {
-    const payloadLength = this.octetsToNextHeader - 24;
+    const payloadLength = this.octetsToNextHeader - 20;
     return new Uint8Array(this.view.buffer, this.view.byteOffset + this.offset + 24, payloadLength);
   }
 }


### PR DESCRIPTION
The last four bytes of `DATA` submessages were being truncated from the `serializedData` property. This fixes the truncation and relevant tests.