### PR TITLE
Fixes for receiving large messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@
 ...
 ```
 
+## Notes
+
+Receiving large (>256KB) messages not be possible with the default Linux networking receive buffer size of 256KB, depending on CPU speed / contention / network speed / many factors. Linux users should set the following sysctls:
+
+```
+sudo sysctl -w net.core.rmem_max=26214400
+sudo sysctl -w net.core.rmem_default=26214400
+sudo sysctl -w net.ipv4.udp_mem=26214400
+```
+
+Or permanently in `/etc/sysctl.conf`:
+
+```
+net.core.rmem_max=26214400
+net.core.rmem_default=26214400
+net.ipv4.udp_mem=26214400
+```
+
 ### Test
 
 `yarn test`

--- a/examples/listener.ts
+++ b/examples/listener.ts
@@ -8,7 +8,7 @@ async function main() {
   const participant = new Participant({
     name: "listener",
     addresses: [address],
-    udpSocketCreate: UdpSocketNode.Create,
+    udpSocketCreate: async () => await UdpSocketNode.Create(),
     log: console,
   });
   await participant.start();

--- a/src/Participant.test.ts
+++ b/src/Participant.test.ts
@@ -10,7 +10,7 @@ describe("Participant", () => {
     const participant = new Participant({
       name: "test",
       addresses: [address],
-      udpSocketCreate: UdpSocketNode.Create,
+      udpSocketCreate: async () => await UdpSocketNode.Create(),
       // log: console,
     });
     await participant.start();

--- a/src/Participant.ts
+++ b/src/Participant.ts
@@ -79,6 +79,7 @@ import {
   UdpRemoteInfo,
   UdpSocket,
   UdpSocketCreate,
+  UdpSocketOptions,
 } from "./transport";
 
 export type ParticipantTuning = {
@@ -109,6 +110,7 @@ export class Participant extends EventEmitter<ParticipantEvents> {
 
   private readonly _addresses: ReadonlyArray<string>;
   private readonly _udpSocketCreate: UdpSocketCreate;
+  private readonly _udpSocketOptions: UdpSocketOptions | undefined;
   private readonly _log?: LoggerService;
   private readonly _participants = new Map<GuidPrefix, ParticipantView>();
   private readonly _writers = new Map<EntityId, Writer>();
@@ -144,6 +146,7 @@ export class Participant extends EventEmitter<ParticipantEvents> {
     domainId?: number;
     guidPrefix?: GuidPrefix;
     udpSocketCreate: UdpSocketCreate;
+    udpSocketOptions?: UdpSocketOptions;
     log?: LoggerService;
     protocolVersion?: ProtocolVersion;
     vendorId?: VendorId;
@@ -176,6 +179,7 @@ export class Participant extends EventEmitter<ParticipantEvents> {
 
     this._addresses = options.addresses;
     this._udpSocketCreate = options.udpSocketCreate;
+    this._udpSocketOptions = options.udpSocketOptions;
     this._log = options.log;
     this._multicastLocator = locatorFromUdpAddress({
       address: MULTICAST_IPv4,
@@ -206,6 +210,7 @@ export class Participant extends EventEmitter<ParticipantEvents> {
     this._multicastSocket = await createMulticastUdpSocket(
       discoveryMulticastPort(this.attributes.domainId),
       this._udpSocketCreate,
+      this._udpSocketOptions,
       this.handleUdpMessage,
       this.handleError,
     );
@@ -220,6 +225,7 @@ export class Participant extends EventEmitter<ParticipantEvents> {
     this._unicastSocket = await createUdpSocket(
       undefined,
       this._udpSocketCreate,
+      this._udpSocketOptions,
       this.handleUdpMessage,
       this.handleError,
     );

--- a/src/Participant.ts
+++ b/src/Participant.ts
@@ -834,30 +834,46 @@ export class Participant extends EventEmitter<ParticipantEvents> {
         continue;
       }
 
-      switch (msg.submessageId) {
-        case SubMessageId.HEARTBEAT:
-          this.handleHeartbeat(message.guidPrefix, msg as HeartbeatView);
-          break;
-        case SubMessageId.ACKNACK:
-          this.handleAckNack(message.guidPrefix, msg as AckNackView);
-          break;
-        case SubMessageId.DATA:
-          this.handleDataMsg(message.guidPrefix, msg as DataMsgView);
-          break;
-        case SubMessageId.GAP:
-          this.handleGap(message.guidPrefix, msg as GapView);
-          break;
-        case SubMessageId.DATA_FRAG:
-          this.handleDataFrag(message.guidPrefix, msg as DataFragView);
-          break;
-        case SubMessageId.HEARTBEAT_FRAG:
-          this.handleHeartbeatFrag(message.guidPrefix, msg as HeartbeatFragView);
-          break;
-        case SubMessageId.NACK_FRAG:
-          this.handleNackFrag(message.guidPrefix, msg as NackFragView);
-          break;
-        default:
-          break;
+      try {
+        switch (msg.submessageId) {
+          case SubMessageId.INFO_TS: {
+            // INFO_TS is already handled by setting effectiveTimestamp on other submessages
+            const infoTs = msg as InfoTsView;
+            this._log?.debug?.(`  [SUBMSG] INFO_TS ${toNanoSec(infoTs.timestamp)}`);
+            break;
+          }
+          case SubMessageId.INFO_DST:
+            // INFO_DST is already handled by setting guidPrefix on other submessages
+            const infoDst = msg as InfoDstView;
+            this._log?.debug?.(`  [SUBMSG] INFO_DST ${infoDst.guidPrefix}`);
+            break;
+          case SubMessageId.HEARTBEAT:
+            this.handleHeartbeat(message.guidPrefix, msg as HeartbeatView);
+            break;
+          case SubMessageId.ACKNACK:
+            this.handleAckNack(message.guidPrefix, msg as AckNackView);
+            break;
+          case SubMessageId.DATA:
+            this.handleDataMsg(message.guidPrefix, msg as DataMsgView);
+            break;
+          case SubMessageId.GAP:
+            this.handleGap(message.guidPrefix, msg as GapView);
+            break;
+          case SubMessageId.DATA_FRAG:
+            this.handleDataFrag(message.guidPrefix, msg as DataFragView);
+            break;
+          case SubMessageId.HEARTBEAT_FRAG:
+            this.handleHeartbeatFrag(message.guidPrefix, msg as HeartbeatFragView);
+            break;
+          case SubMessageId.NACK_FRAG:
+            this.handleNackFrag(message.guidPrefix, msg as NackFragView);
+            break;
+          default:
+            this._log?.warn?.(`ignoring unhandled submessage ${msg.submessageId}`);
+            break;
+        }
+      } catch (err) {
+        this.handleError(err as Error);
       }
     }
   };

--- a/src/Participant.ts
+++ b/src/Participant.ts
@@ -848,11 +848,12 @@ export class Participant extends EventEmitter<ParticipantEvents> {
             this._log?.debug?.(`  [SUBMSG] INFO_TS ${toNanoSec(infoTs.timestamp)}`);
             break;
           }
-          case SubMessageId.INFO_DST:
+          case SubMessageId.INFO_DST: {
             // INFO_DST is already handled by setting guidPrefix on other submessages
             const infoDst = msg as InfoDstView;
             this._log?.debug?.(`  [SUBMSG] INFO_DST ${infoDst.guidPrefix}`);
             break;
+          }
           case SubMessageId.HEARTBEAT:
             this.handleHeartbeat(message.guidPrefix, msg as HeartbeatView);
             break;

--- a/src/Participant.ts
+++ b/src/Participant.ts
@@ -804,7 +804,7 @@ export class Participant extends EventEmitter<ParticipantEvents> {
 
   private handleError = (err: Error): void => {
     if (this._running) {
-      this._log?.warn?.(`${this.toString()} error: ${err}`);
+      this._log?.warn?.(`[ERROR][${this.name}] ${err}`);
       this.emit("error", err);
     }
   };

--- a/src/history/ReaderHistoryCache.ts
+++ b/src/history/ReaderHistoryCache.ts
@@ -95,6 +95,7 @@ export class ReaderHistoryCache {
       return new SequenceNumberSet(lastSeqNumber, 0);
     }
 
+    // Record the sequence numbers of all missing entries in _sequenceToEntry
     const numBits = Math.min(1 + Number(lastSeqNumber - firstSeqNumber), 256);
     const set = new SequenceNumberSet(firstSeqNumber, numBits);
     let hasAll = true;

--- a/src/nodejs/UdpSocketNode.ts
+++ b/src/nodejs/UdpSocketNode.ts
@@ -1,7 +1,16 @@
 import dgram from "dgram";
 import EventEmitter from "eventemitter3";
 
-import { UdpAddress, UdpBindOptions, UdpSocket, UdpSocketEvents } from "../transport";
+import {
+  UdpAddress,
+  UdpBindOptions,
+  UdpSocket,
+  UdpSocketEvents,
+  UdpSocketOptions,
+} from "../transport";
+
+const SEND_BUFFER_SIZE = 262144;
+const RECV_BUFFER_SIZE = 26214400;
 
 export class UdpSocketNode extends EventEmitter<UdpSocketEvents> implements UdpSocket {
   private _socket: dgram.Socket;
@@ -92,7 +101,17 @@ export class UdpSocketNode extends EventEmitter<UdpSocketEvents> implements UdpS
     this._socket.setMulticastTTL(ttl);
   }
 
-  static async Create(this: void): Promise<UdpSocket> {
-    return new UdpSocketNode(dgram.createSocket({ type: "udp4", reuseAddr: true }));
+  static async Create(options?: UdpSocketOptions): Promise<UdpSocket> {
+    return new UdpSocketNode(
+      dgram.createSocket({
+        ...{
+          type: "udp4",
+          reuseAddr: true,
+          sendBufferSize: SEND_BUFFER_SIZE,
+          recvBufferSize: RECV_BUFFER_SIZE,
+        },
+        ...options,
+      }),
+    );
   }
 }

--- a/src/routing/DataFragments.test.ts
+++ b/src/routing/DataFragments.test.ts
@@ -1,0 +1,154 @@
+import { DataFragments } from "./DataFragments";
+
+describe("DataFragments", () => {
+  it("should work with even fragment sizes", async () => {
+    const fragments = new DataFragments(10, 2);
+    expect(fragments.totalBytes).toBe(10);
+    expect(fragments.fragmentSize).toBe(2);
+    expect(fragments.lastFragmentSize).toBe(2);
+    expect(fragments.fragmentCount).toBe(5);
+    expect(fragments.fragments).toHaveLength(5);
+    expect(fragments.remainingFragments).toBe(5);
+    expect(Array.from(fragments.missingFragments(0))).toEqual([]);
+    expect(Array.from(fragments.missingFragments(5))).toEqual([0, 1, 2, 3, 4]);
+    expect(fragments.data()).toBeUndefined();
+
+    expect(fragments.addFragment(0, new Uint8Array([0, 1]))).toBe(false);
+    expect(fragments.remainingFragments).toBe(4);
+    expect(fragments.hasUpTo(0)).toBe(true);
+    expect(fragments.hasUpTo(1)).toBe(false);
+    expect(Array.from(fragments.missingFragments(5))).toEqual([1, 2, 3, 4]);
+    expect(fragments.data()).toBeUndefined();
+
+    expect(fragments.addFragment(1, new Uint8Array([2, 3]))).toBe(false);
+    expect(fragments.remainingFragments).toBe(3);
+    expect(fragments.hasUpTo(0)).toBe(true);
+    expect(fragments.hasUpTo(1)).toBe(true);
+    expect(fragments.hasUpTo(2)).toBe(false);
+    expect(Array.from(fragments.missingFragments(5))).toEqual([2, 3, 4]);
+    expect(fragments.data()).toBeUndefined();
+
+    expect(fragments.addFragment(2, new Uint8Array([4, 5]))).toBe(false);
+    expect(fragments.remainingFragments).toBe(2);
+    expect(fragments.hasUpTo(0)).toBe(true);
+    expect(fragments.hasUpTo(1)).toBe(true);
+    expect(fragments.hasUpTo(2)).toBe(true);
+    expect(fragments.hasUpTo(3)).toBe(false);
+    expect(Array.from(fragments.missingFragments(5))).toEqual([3, 4]);
+    expect(fragments.data()).toBeUndefined();
+
+    expect(fragments.addFragment(3, new Uint8Array([6, 7]))).toBe(false);
+    expect(fragments.remainingFragments).toBe(1);
+    expect(fragments.hasUpTo(0)).toBe(true);
+    expect(fragments.hasUpTo(1)).toBe(true);
+    expect(fragments.hasUpTo(2)).toBe(true);
+    expect(fragments.hasUpTo(3)).toBe(true);
+    expect(fragments.hasUpTo(4)).toBe(false);
+    expect(Array.from(fragments.missingFragments(5))).toEqual([4]);
+    expect(fragments.data()).toBeUndefined();
+
+    expect(fragments.addFragment(4, new Uint8Array([8, 9]))).toBe(true);
+    expect(fragments.remainingFragments).toBe(0);
+    expect(fragments.hasUpTo(0)).toBe(true);
+    expect(fragments.hasUpTo(1)).toBe(true);
+    expect(fragments.hasUpTo(2)).toBe(true);
+    expect(fragments.hasUpTo(3)).toBe(true);
+    expect(fragments.hasUpTo(4)).toBe(true);
+    expect(Array.from(fragments.missingFragments(5))).toEqual([]);
+    expect(fragments.data()).toEqual(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
+  });
+
+  it("should work with a different lastFragmentSize", async () => {
+    const fragments = new DataFragments(10, 3);
+    expect(fragments.totalBytes).toBe(10);
+    expect(fragments.fragmentSize).toBe(3);
+    expect(fragments.lastFragmentSize).toBe(1);
+    expect(fragments.fragmentCount).toBe(4);
+    expect(fragments.fragments).toHaveLength(4);
+    expect(fragments.remainingFragments).toBe(4);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([0, 1, 2, 3]);
+    expect(fragments.data()).toBeUndefined();
+
+    expect(fragments.addFragment(0, new Uint8Array([0, 1, 2]))).toBe(false);
+    expect(fragments.remainingFragments).toBe(3);
+    expect(fragments.hasUpTo(0)).toBe(true);
+    expect(fragments.hasUpTo(1)).toBe(false);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([1, 2, 3]);
+    expect(fragments.data()).toBeUndefined();
+
+    expect(fragments.addFragment(1, new Uint8Array([3, 4, 5]))).toBe(false);
+    expect(fragments.remainingFragments).toBe(2);
+    expect(fragments.hasUpTo(0)).toBe(true);
+    expect(fragments.hasUpTo(1)).toBe(true);
+    expect(fragments.hasUpTo(2)).toBe(false);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([2, 3]);
+    expect(fragments.data()).toBeUndefined();
+
+    expect(fragments.addFragment(2, new Uint8Array([6, 7, 8]))).toBe(false);
+    expect(fragments.remainingFragments).toBe(1);
+    expect(fragments.hasUpTo(0)).toBe(true);
+    expect(fragments.hasUpTo(1)).toBe(true);
+    expect(fragments.hasUpTo(2)).toBe(true);
+    expect(fragments.hasUpTo(3)).toBe(false);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([3]);
+    expect(fragments.data()).toBeUndefined();
+
+    expect(fragments.addFragment(3, new Uint8Array([9]))).toBe(true);
+    expect(fragments.remainingFragments).toBe(0);
+    expect(fragments.hasUpTo(0)).toBe(true);
+    expect(fragments.hasUpTo(1)).toBe(true);
+    expect(fragments.hasUpTo(2)).toBe(true);
+    expect(fragments.hasUpTo(3)).toBe(true);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([]);
+    expect(fragments.data()).toEqual(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
+  });
+
+  it("should work with out of order fragments", async () => {
+    const fragments = new DataFragments(10, 3);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([0, 1, 2, 3]);
+
+    expect(fragments.addFragment(1, new Uint8Array([3, 4, 5]))).toBe(false);
+    expect(fragments.remainingFragments).toBe(3);
+    expect(fragments.hasUpTo(0)).toBe(false);
+    expect(fragments.hasUpTo(1)).toBe(false);
+    expect(fragments.hasUpTo(2)).toBe(false);
+    expect(fragments.hasUpTo(3)).toBe(false);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([0, 2, 3]);
+    expect(fragments.data()).toBeUndefined();
+
+    expect(fragments.addFragment(3, new Uint8Array([9]))).toBe(false);
+    expect(fragments.remainingFragments).toBe(2);
+    expect(fragments.hasUpTo(0)).toBe(false);
+    expect(fragments.hasUpTo(1)).toBe(false);
+    expect(fragments.hasUpTo(2)).toBe(false);
+    expect(fragments.hasUpTo(3)).toBe(false);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([0, 2]);
+
+    expect(fragments.addFragment(0, new Uint8Array([0, 1, 2]))).toBe(false);
+    expect(fragments.remainingFragments).toBe(1);
+    expect(fragments.hasUpTo(0)).toBe(true);
+    expect(fragments.hasUpTo(1)).toBe(true);
+    expect(fragments.hasUpTo(2)).toBe(false);
+    expect(fragments.hasUpTo(3)).toBe(false);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([2]);
+    expect(fragments.data()).toBeUndefined();
+
+    expect(fragments.addFragment(0, new Uint8Array([0, 1, 2]))).toBe(false);
+    expect(fragments.remainingFragments).toBe(1);
+    expect(fragments.hasUpTo(0)).toBe(true);
+    expect(fragments.hasUpTo(1)).toBe(true);
+    expect(fragments.hasUpTo(2)).toBe(false);
+    expect(fragments.hasUpTo(3)).toBe(false);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([2]);
+    expect(fragments.data()).toBeUndefined();
+
+    expect(fragments.addFragment(2, new Uint8Array([6, 7, 8]))).toBe(true);
+    expect(fragments.remainingFragments).toBe(0);
+    expect(fragments.hasUpTo(0)).toBe(true);
+    expect(fragments.hasUpTo(1)).toBe(true);
+    expect(fragments.hasUpTo(2)).toBe(true);
+    expect(fragments.hasUpTo(3)).toBe(true);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([]);
+    expect(fragments.data()).toEqual(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
+  });
+});

--- a/src/routing/DataFragments.ts
+++ b/src/routing/DataFragments.ts
@@ -56,8 +56,9 @@ export class DataFragments {
     return true;
   }
 
-  *missingFragments(): Generator<number> {
-    for (let i = 0; i < this.fragmentCount; i++) {
+  *missingFragments(lastFragmentNumber: number): Generator<number> {
+    const limit = Math.min(this.fragmentCount, lastFragmentNumber);
+    for (let i = 0; i < limit; i++) {
       if (this.fragments[i] == undefined) {
         yield i;
       }

--- a/src/transport/networkTypes.ts
+++ b/src/transport/networkTypes.ts
@@ -26,6 +26,14 @@ export type UdpBindOptions = {
   address?: string;
 };
 
+export type UdpSocketOptions = {
+  type: "udp4" | "udp6";
+  reuseAddr?: boolean | undefined;
+  ipv6Only?: boolean | undefined;
+  recvBufferSize?: number | undefined;
+  sendBufferSize?: number | undefined;
+};
+
 export interface UdpSocketEvents {
   close: () => void;
   listening: () => void;
@@ -60,5 +68,5 @@ export interface UdpSocket {
 }
 
 export interface UdpSocketCreate {
-  (options: { type: "udp4" | "udp6" }): Promise<UdpSocket>;
+  (options: UdpSocketOptions): Promise<UdpSocket>;
 }

--- a/src/transport/udpTransport.ts
+++ b/src/transport/udpTransport.ts
@@ -1,6 +1,12 @@
 import { Locator, LocatorKind, ipv6ToBytes, ipv4ToBytes } from "../common";
 import { Message } from "../messaging";
-import { UdpAddress, UdpRemoteInfo, UdpSocket, UdpSocketCreate } from "./networkTypes";
+import {
+  UdpAddress,
+  UdpRemoteInfo,
+  UdpSocket,
+  UdpSocketCreate,
+  UdpSocketOptions,
+} from "./networkTypes";
 
 export const MULTICAST_IPv4 = "239.255.0.1";
 
@@ -64,10 +70,11 @@ export async function sendMessageToUdp(
 export async function createUdpSocket(
   address: string | undefined,
   udpSocketCreate: UdpSocketCreate,
+  udpSocketOptions: UdpSocketOptions | undefined,
   messageHandler: (data: Uint8Array, rinfo: UdpRemoteInfo) => void,
   errorHandler: (err: Error) => void,
 ): Promise<UdpSocket> {
-  const socket = await udpSocketCreate({ type: "udp4" });
+  const socket = await udpSocketCreate({ ...{ type: "udp4" }, ...udpSocketOptions });
   socket.on("error", errorHandler);
   socket.on("message", messageHandler);
   await socket.bind({ address });
@@ -77,10 +84,11 @@ export async function createUdpSocket(
 export async function createMulticastUdpSocket(
   port: number,
   udpSocketCreate: UdpSocketCreate,
+  udpSocketOptions: UdpSocketOptions | undefined,
   messageHandler: (data: Uint8Array, rinfo: UdpRemoteInfo) => void,
   errorHandler: (err: Error) => void,
 ): Promise<UdpSocket> {
-  const socket = await udpSocketCreate({ type: "udp4" });
+  const socket = await udpSocketCreate({ ...{ type: "udp4" }, ...udpSocketOptions });
   socket.on("error", errorHandler);
   socket.on("message", messageHandler);
   await socket.bind({ port });


### PR DESCRIPTION
NOTE: Receiving large messages such as 1MB raw image frames may not be possible with the default Linux networking receive buffer size of 256KB, depending on CPU speed / contention / network speed / many factors. Linux users should set the following sysctls:

```
sudo sysctl -w net.core.rmem_max=26214400
sudo sysctl -w net.core.rmem_default=26214400
sudo sysctl -w net.ipv4.udp_mem=26214400
```

Or permanently in `/etc/sysctl.conf`:

```
net.core.rmem_max=26214400
net.core.rmem_default=26214400
net.ipv4.udp_mem=26214400
```

**Public-Facing Changes**

- `udpSocketOptions` can be specified when constructing a `Participant`
- Multiple protocol bugs have been fixed related to receiving large messages

**Description**

- Add udpSocketOptions to Participant constructor options, set default SO_RCVBUF / SO_SNDBUF
- Don't send ACKNACK for seqnums where we are missing one or more fragments, send NACK_FRAG instead
- Fix error logging formatting
- Catch message handling exceptions
- DATA_FRAG debug logging
- HEARTBEAT_FRAG debug logging
- Fix bug in NACK_FRAG numBits calculation
- DataFragments unit tests
