### PR TITLE
Protocol fixes for receiving large messages

### DIFF
--- a/src/Participant.ts
+++ b/src/Participant.ts
@@ -941,7 +941,7 @@ export class Participant extends EventEmitter<ParticipantEvents> {
     const writerGuid = makeGuid(guidPrefix, heartbeat.writerEntityId);
     const readers = this.getReaders(heartbeat.readerEntityId, writerGuid);
     if (readers.length === 0) {
-      this._log?.info?.(
+      this._log?.warn?.(
         `received unrecognized heartbeat reader=${heartbeat.readerEntityId}, writer=${writerGuid}`,
       );
       return;

--- a/src/Participant.ts
+++ b/src/Participant.ts
@@ -749,11 +749,10 @@ export class Participant extends EventEmitter<ParticipantEvents> {
 
     const base = missing[0]!;
     const lastMissing = missing[missing.length - 1]!;
-    const numBits = lastMissing - base;
+    const numBits = Math.min(1 + lastMissing - base, 256);
     const state = new FragmentNumberSet(base, numBits);
-    for (const idx of missing) {
-      const fragmentNum = idx + 1;
-      if (fragmentNum > lastFragmentNumber) {
+    for (const fragmentNum of missing) {
+      if (fragmentNum > lastFragmentNumber || fragmentNum - base >= numBits) {
         break;
       }
       state.add(fragmentNum);

--- a/src/Participant.ts
+++ b/src/Participant.ts
@@ -688,6 +688,9 @@ export class Participant extends EventEmitter<ParticipantEvents> {
         break;
       }
     }
+    if (endSeq > lastSeqNumber) {
+      endSeq = lastSeqNumber;
+    }
 
     if (endSeq < firstAvailableSeqNumber) {
       // No sequence numbers need AckNack (only sending NackFrag)

--- a/src/common/FragmentNumberSet.ts
+++ b/src/common/FragmentNumberSet.ts
@@ -68,7 +68,9 @@ export class FragmentNumberSet {
 
   toString(): string {
     const missing = Array.from(this.fragmentNumbers());
-    return `base=${this.base}, numBits=${this.numBits}, missing=[${missing.join(",")}]`;
+    return `FragmentNumberSet<base=${this.base}, numBits=${this.numBits}, missing=[${missing.join(
+      ",",
+    )}]>`;
   }
 
   static fromData(view: DataView, offset: number, littleEndian: boolean): FragmentNumberSet {

--- a/src/history/ReaderHistoryCache.test.ts
+++ b/src/history/ReaderHistoryCache.test.ts
@@ -39,9 +39,9 @@ describe("ReaderHistoryCache", () => {
     expect(history.get(3n)).toBeUndefined();
     expect(history.get(4n)).toBeUndefined();
     expect(missing.size).toEqual(16);
-    expect(missing.base).toEqual(1n);
-    expect(missing.numBits).toEqual(3);
-    expect(missing.bitmap).toEqual(new Uint32Array([1610612736, 0, 0, 0, 0, 0, 0, 0]));
+    expect(missing.base).toEqual(2n);
+    expect(missing.numBits).toEqual(2);
+    expect(missing.bitmap).toEqual(new Uint32Array([3221225472, 0, 0, 0, 0, 0, 0, 0]));
 
     const secondEntry = {
       timestamp: { sec: 2, nsec: 0 },
@@ -62,9 +62,9 @@ describe("ReaderHistoryCache", () => {
     expect(history.get(3n)).toBeUndefined();
     expect(history.get(4n)).toBeUndefined();
     expect(missing.size).toEqual(16);
-    expect(missing.base).toEqual(1n);
-    expect(missing.numBits).toEqual(3);
-    expect(missing.bitmap).toEqual(new Uint32Array([536870912, 0, 0, 0, 0, 0, 0, 0]));
+    expect(missing.base).toEqual(3n);
+    expect(missing.numBits).toEqual(1);
+    expect(missing.bitmap).toEqual(new Uint32Array([2147483648, 0, 0, 0, 0, 0, 0, 0]));
 
     const thirdEntry = {
       timestamp: { sec: 3, nsec: 0 },
@@ -174,9 +174,9 @@ describe("ReaderHistoryCache", () => {
     expect(history.get(3n)).toBeUndefined();
     expect(history.get(4n)).toBeUndefined();
     expect(missing.size).toEqual(16);
-    expect(missing.base).toEqual(1n);
-    expect(missing.numBits).toEqual(3);
-    expect(missing.bitmap).toEqual(new Uint32Array([536870912, 0, 0, 0, 0, 0, 0, 0]));
+    expect(missing.base).toEqual(3n);
+    expect(missing.numBits).toEqual(1);
+    expect(missing.bitmap).toEqual(new Uint32Array([2147483648, 0, 0, 0, 0, 0, 0, 0]));
 
     const fourthEntry = {
       timestamp: { sec: 4, nsec: 0 },
@@ -197,9 +197,9 @@ describe("ReaderHistoryCache", () => {
     expect(history.get(3n)).toBeUndefined();
     expect(history.get(4n)).toBe(fourthEntry);
     expect(missing.size).toEqual(16);
-    expect(missing.base).toEqual(1n);
-    expect(missing.numBits).toEqual(3);
-    expect(missing.bitmap).toEqual(new Uint32Array([536870912, 0, 0, 0, 0, 0, 0, 0]));
+    expect(missing.base).toEqual(3n);
+    expect(missing.numBits).toEqual(1);
+    expect(missing.bitmap).toEqual(new Uint32Array([2147483648, 0, 0, 0, 0, 0, 0, 0]));
     expect(firstEntry.kind).toEqual(ChangeKind.Alive);
 
     const thirdEntry = {
@@ -253,9 +253,9 @@ describe("ReaderHistoryCache", () => {
     expect(history.get(5n)).toBeUndefined();
     expect(history.get(6n)).toBeUndefined();
     expect(missing.size).toEqual(16);
-    expect(missing.base).toEqual(1n);
-    expect(missing.numBits).toEqual(3);
-    expect(missing.bitmap).toEqual(new Uint32Array([1610612736, 0, 0, 0, 0, 0, 0, 0]));
+    expect(missing.base).toEqual(2n);
+    expect(missing.numBits).toEqual(2);
+    expect(missing.bitmap).toEqual(new Uint32Array([3221225472, 0, 0, 0, 0, 0, 0, 0]));
 
     const secondEntry = {
       timestamp: { sec: 2, nsec: 0 },
@@ -306,9 +306,9 @@ describe("ReaderHistoryCache", () => {
     expect(history.get(5n)).toBeUndefined();
     expect(history.get(6n)).toBe(sixthGap);
     expect(missing.size).toEqual(16);
-    expect(missing.base).toEqual(1n);
-    expect(missing.numBits).toEqual(3);
-    expect(missing.bitmap).toEqual(new Uint32Array([1610612736, 0, 0, 0, 0, 0, 0, 0]));
+    expect(missing.base).toEqual(2n);
+    expect(missing.numBits).toEqual(2);
+    expect(missing.bitmap).toEqual(new Uint32Array([3221225472, 0, 0, 0, 0, 0, 0, 0]));
     expect(secondEntry.kind).toEqual(ChangeKind.Alive);
 
     const fifthEntry = {

--- a/src/routing/DataFragments.test.ts
+++ b/src/routing/DataFragments.test.ts
@@ -1,6 +1,33 @@
 import { DataFragments } from "./DataFragments";
 
 describe("DataFragments", () => {
+  it("should work for a real-world use case", async () => {
+    const fragmentTracker = new DataFragments(3146300, 1344);
+    expect(fragmentTracker.totalBytes).toBe(3146300);
+    expect(fragmentTracker.fragmentSize).toBe(1344);
+    expect(fragmentTracker.fragmentCount).toBe(2341);
+    expect(fragmentTracker.lastFragmentSize).toBe(1340);
+    expect(fragmentTracker.remainingFragments).toBe(2341);
+    expect(fragmentTracker.hasUpTo(0)).toBe(false);
+
+    const fragmentStartingNum = 1;
+    const lastFragmentNumber = 2341;
+    const fragments = [new Uint8Array(1344)];
+    for (let i = 0; i < fragments.length; i++) {
+      const fragment = fragments[i]!;
+      const index = fragmentStartingNum - 1 + i;
+      fragmentTracker.addFragment(index, fragment);
+    }
+
+    expect(fragmentTracker.remainingFragments).toBe(lastFragmentNumber - fragments.length);
+    expect(fragmentTracker.hasUpTo(0)).toBe(true);
+    expect(fragmentTracker.hasUpTo(1)).toBe(false);
+
+    const missing = Array.from(fragmentTracker.missingFragments(lastFragmentNumber));
+    expect(missing).toHaveLength(2341 - fragments.length);
+    expect(missing[0]).toBe(2);
+  });
+
   it("should work with even fragment sizes", async () => {
     const fragments = new DataFragments(10, 2);
     expect(fragments.totalBytes).toBe(10);
@@ -10,14 +37,14 @@ describe("DataFragments", () => {
     expect(fragments.fragments).toHaveLength(5);
     expect(fragments.remainingFragments).toBe(5);
     expect(Array.from(fragments.missingFragments(0))).toEqual([]);
-    expect(Array.from(fragments.missingFragments(5))).toEqual([0, 1, 2, 3, 4]);
+    expect(Array.from(fragments.missingFragments(5))).toEqual([1, 2, 3, 4, 5]);
     expect(fragments.data()).toBeUndefined();
 
     expect(fragments.addFragment(0, new Uint8Array([0, 1]))).toBe(false);
     expect(fragments.remainingFragments).toBe(4);
     expect(fragments.hasUpTo(0)).toBe(true);
     expect(fragments.hasUpTo(1)).toBe(false);
-    expect(Array.from(fragments.missingFragments(5))).toEqual([1, 2, 3, 4]);
+    expect(Array.from(fragments.missingFragments(5))).toEqual([2, 3, 4, 5]);
     expect(fragments.data()).toBeUndefined();
 
     expect(fragments.addFragment(1, new Uint8Array([2, 3]))).toBe(false);
@@ -25,7 +52,7 @@ describe("DataFragments", () => {
     expect(fragments.hasUpTo(0)).toBe(true);
     expect(fragments.hasUpTo(1)).toBe(true);
     expect(fragments.hasUpTo(2)).toBe(false);
-    expect(Array.from(fragments.missingFragments(5))).toEqual([2, 3, 4]);
+    expect(Array.from(fragments.missingFragments(5))).toEqual([3, 4, 5]);
     expect(fragments.data()).toBeUndefined();
 
     expect(fragments.addFragment(2, new Uint8Array([4, 5]))).toBe(false);
@@ -34,7 +61,7 @@ describe("DataFragments", () => {
     expect(fragments.hasUpTo(1)).toBe(true);
     expect(fragments.hasUpTo(2)).toBe(true);
     expect(fragments.hasUpTo(3)).toBe(false);
-    expect(Array.from(fragments.missingFragments(5))).toEqual([3, 4]);
+    expect(Array.from(fragments.missingFragments(5))).toEqual([4, 5]);
     expect(fragments.data()).toBeUndefined();
 
     expect(fragments.addFragment(3, new Uint8Array([6, 7]))).toBe(false);
@@ -44,7 +71,7 @@ describe("DataFragments", () => {
     expect(fragments.hasUpTo(2)).toBe(true);
     expect(fragments.hasUpTo(3)).toBe(true);
     expect(fragments.hasUpTo(4)).toBe(false);
-    expect(Array.from(fragments.missingFragments(5))).toEqual([4]);
+    expect(Array.from(fragments.missingFragments(5))).toEqual([5]);
     expect(fragments.data()).toBeUndefined();
 
     expect(fragments.addFragment(4, new Uint8Array([8, 9]))).toBe(true);
@@ -66,14 +93,14 @@ describe("DataFragments", () => {
     expect(fragments.fragmentCount).toBe(4);
     expect(fragments.fragments).toHaveLength(4);
     expect(fragments.remainingFragments).toBe(4);
-    expect(Array.from(fragments.missingFragments(4))).toEqual([0, 1, 2, 3]);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([1, 2, 3, 4]);
     expect(fragments.data()).toBeUndefined();
 
     expect(fragments.addFragment(0, new Uint8Array([0, 1, 2]))).toBe(false);
     expect(fragments.remainingFragments).toBe(3);
     expect(fragments.hasUpTo(0)).toBe(true);
     expect(fragments.hasUpTo(1)).toBe(false);
-    expect(Array.from(fragments.missingFragments(4))).toEqual([1, 2, 3]);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([2, 3, 4]);
     expect(fragments.data()).toBeUndefined();
 
     expect(fragments.addFragment(1, new Uint8Array([3, 4, 5]))).toBe(false);
@@ -81,7 +108,7 @@ describe("DataFragments", () => {
     expect(fragments.hasUpTo(0)).toBe(true);
     expect(fragments.hasUpTo(1)).toBe(true);
     expect(fragments.hasUpTo(2)).toBe(false);
-    expect(Array.from(fragments.missingFragments(4))).toEqual([2, 3]);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([3, 4]);
     expect(fragments.data()).toBeUndefined();
 
     expect(fragments.addFragment(2, new Uint8Array([6, 7, 8]))).toBe(false);
@@ -90,7 +117,7 @@ describe("DataFragments", () => {
     expect(fragments.hasUpTo(1)).toBe(true);
     expect(fragments.hasUpTo(2)).toBe(true);
     expect(fragments.hasUpTo(3)).toBe(false);
-    expect(Array.from(fragments.missingFragments(4))).toEqual([3]);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([4]);
     expect(fragments.data()).toBeUndefined();
 
     expect(fragments.addFragment(3, new Uint8Array([9]))).toBe(true);
@@ -105,7 +132,7 @@ describe("DataFragments", () => {
 
   it("should work with out of order fragments", async () => {
     const fragments = new DataFragments(10, 3);
-    expect(Array.from(fragments.missingFragments(4))).toEqual([0, 1, 2, 3]);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([1, 2, 3, 4]);
 
     expect(fragments.addFragment(1, new Uint8Array([3, 4, 5]))).toBe(false);
     expect(fragments.remainingFragments).toBe(3);
@@ -113,7 +140,7 @@ describe("DataFragments", () => {
     expect(fragments.hasUpTo(1)).toBe(false);
     expect(fragments.hasUpTo(2)).toBe(false);
     expect(fragments.hasUpTo(3)).toBe(false);
-    expect(Array.from(fragments.missingFragments(4))).toEqual([0, 2, 3]);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([1, 3, 4]);
     expect(fragments.data()).toBeUndefined();
 
     expect(fragments.addFragment(3, new Uint8Array([9]))).toBe(false);
@@ -122,7 +149,7 @@ describe("DataFragments", () => {
     expect(fragments.hasUpTo(1)).toBe(false);
     expect(fragments.hasUpTo(2)).toBe(false);
     expect(fragments.hasUpTo(3)).toBe(false);
-    expect(Array.from(fragments.missingFragments(4))).toEqual([0, 2]);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([1, 3]);
 
     expect(fragments.addFragment(0, new Uint8Array([0, 1, 2]))).toBe(false);
     expect(fragments.remainingFragments).toBe(1);
@@ -130,7 +157,7 @@ describe("DataFragments", () => {
     expect(fragments.hasUpTo(1)).toBe(true);
     expect(fragments.hasUpTo(2)).toBe(false);
     expect(fragments.hasUpTo(3)).toBe(false);
-    expect(Array.from(fragments.missingFragments(4))).toEqual([2]);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([3]);
     expect(fragments.data()).toBeUndefined();
 
     expect(fragments.addFragment(0, new Uint8Array([0, 1, 2]))).toBe(false);
@@ -139,7 +166,7 @@ describe("DataFragments", () => {
     expect(fragments.hasUpTo(1)).toBe(true);
     expect(fragments.hasUpTo(2)).toBe(false);
     expect(fragments.hasUpTo(3)).toBe(false);
-    expect(Array.from(fragments.missingFragments(4))).toEqual([2]);
+    expect(Array.from(fragments.missingFragments(4))).toEqual([3]);
     expect(fragments.data()).toBeUndefined();
 
     expect(fragments.addFragment(2, new Uint8Array([6, 7, 8]))).toBe(true);

--- a/src/routing/DataFragments.ts
+++ b/src/routing/DataFragments.ts
@@ -56,11 +56,12 @@ export class DataFragments {
     return true;
   }
 
+  /** Note: returns fragment numbers (index + 1), not indices */
   *missingFragments(lastFragmentNumber: number): Generator<number> {
     const limit = Math.min(this.fragmentCount, lastFragmentNumber);
     for (let i = 0; i < limit; i++) {
       if (this.fragments[i] == undefined) {
-        yield i;
+        yield i + 1;
       }
     }
   }


### PR DESCRIPTION
**Public-Facing Changes**
- Protocol fixes for receiving large messages (sent with DATA_FRAG)

**Description**
This includes a variety of fixes for DATA_FRAG and NACK_FRAG, and improves ACKNACKs with more compact SNSs.

- Fix incorrect lastSeqNumber in heartbeat updates / ACKNACKs
- Fix numBits calculation for NACK_FRAGs
- Fix DataFragments#missingFragments() to return fragment numbers, not indices
- Improve SequenceNumberSet generation by setting baseNum to the first missing sequence number
